### PR TITLE
Change authentication method to Bearer token instead of access_token

### DIFF
--- a/API.ts
+++ b/API.ts
@@ -42,10 +42,12 @@ export default class API {
         await this.refreshAccessToken()
         if (!params) params = {}
         params.filter = "for_ios"
-        params.access_token = this.accessToken
+        let headersWithAuth = Object.assign(this.headers, {
+            authorization: 'Bearer ' + this.accessToken
+        })
         if (endpoint.startsWith("/")) endpoint = endpoint.slice(1)
         endpoint = appURL + endpoint
-        const response = await axios.get(endpoint, {json: true, form: true, headers: this.headers, params} as AxiosRequestConfig).then((r) => r.data)
+        const response = await axios.get(endpoint, {json: true, form: true, headers: headersWithAuth, params} as AxiosRequestConfig).then((r) => r.data)
         return response
     }
 
@@ -65,8 +67,10 @@ export default class API {
     public next = async (nextUrl: string) => {
         await this.refreshAccessToken()
         const {baseUrl, params} = this.destructureParams(nextUrl)
-        params.access_token = this.accessToken
-        const response = await axios.get(baseUrl, {params, headers: this.headers}).then((r) => r.data)
+        let headersWithAuth = Object.assign(this.headers, {
+            authorization: 'Bearer ' + this.accessToken
+        })
+        const response = await axios.get(baseUrl, {params, headers: headersWithAuth}).then((r) => r.data)
         return response
     }
 


### PR DESCRIPTION
Hey @Moebits, how are you doing? It's been a while.

I got a bug report from my project https://github.com/rayriffy/pixiv-bookmarks-visualizer/issues/1 having a problem where some tags in illust cannot be found from API response. Upon further investigation I found that by authenticate API with `Authentation` header has completely different response when comparing to `access_token=` method.

You can try comparing results between these both response by using following cURL command.

| `access_token` to search params | `Authentication` header |
| - | - |
| `curl --location 'https://app-api.pixiv.net/v1/user/bookmarks/illust?user_id=12593750&restrict=public&access_token=<your_token>'` | `curl --location 'https://app-api.pixiv.net/v1/user/bookmarks/illust?user_id=12593750&restrict=public' --header 'Authorization: Bearer <your_token>'`|

This PR will replace those authentication method to a newer one.