### PR TITLE
Add global axios option support

### DIFF
--- a/API.ts
+++ b/API.ts
@@ -1,4 +1,5 @@
-import axios, {AxiosRequestConfig} from "axios"
+import {axiosInstance as axios} from "./entities/AxiosInstance"
+import {AxiosRequestConfig} from "axios"
 import {ParsedUrlQueryInput, stringify} from "querystring"
 import {URLSearchParams} from "url"
 import {PixivAPIResponse} from "./types/ApiTypes"

--- a/entities/AxiosInstance.ts
+++ b/entities/AxiosInstance.ts
@@ -1,0 +1,7 @@
+import axios, { AxiosInstance, AxiosRequestConfig } from "axios"
+// ESM import is a readonly view pointing to the original var
+// which provids realtime binding
+export let axiosInstance: AxiosInstance = axios;
+export const updateAxiosInstance = (options?: AxiosRequestConfig) => {
+  axiosInstance = axios.create(options);
+}

--- a/entities/Search.ts
+++ b/entities/Search.ts
@@ -1,7 +1,7 @@
 import api from "../API"
 import Pixiv from "../pixiv"
 import replace from "../Translate"
-import axios from "axios"
+import {axiosInstance as axios} from "./AxiosInstance"
 import {PixivAutoComplete, PixivAutoCompleteV2, PixivIllust,
 PixivIllustSearch, PixivNovel, PixivNovelSearch, PixivParams, PixivUserSearch} from "../types"
 

--- a/entities/Util.ts
+++ b/entities/Util.ts
@@ -1,4 +1,4 @@
-import axios from "axios"
+import {axiosInstance as axios} from "./AxiosInstance"
 import * as fs from "fs"
 import {imageSize} from "image-size"
 import * as path from "path"

--- a/pixiv.ts
+++ b/pixiv.ts
@@ -1,4 +1,5 @@
-import axios, {AxiosRequestConfig} from "axios"
+import {axiosInstance as axios, updateAxiosInstance} from "./entities/AxiosInstance"
+import {AxiosRequestConfig} from "axios"
 import * as crypto from "crypto"
 import {ParsedUrlQueryInput, stringify} from "querystring"
 import api from "./API"
@@ -75,7 +76,8 @@ export default class Pixiv {
     /**
      * Logs into Pixiv with your username and password, or refresh token if it is available.
      */
-    public static login = async (username: string, password: string) => {
+    public static login = async (username: string, password: string, options?: AxiosRequestConfig) => {
+        updateAxiosInstance(options)
         if (!username || !password) {
             const missing = username ? "password" : (password ? "username" : "username and password")
             return Promise.reject(`You must provide a ${missing} in order to login!`)
@@ -98,7 +100,8 @@ export default class Pixiv {
     /**
      * Logs in with username and password only.
      */
-    public static passwordLogin = async (username: string, password: string) => {
+    public static passwordLogin = async (username: string, password: string, options?: AxiosRequestConfig) => {
+        updateAxiosInstance(options)
         if (!username || !password) {
             const missing = username ? "password" : (password ? "username" : "username and password")
             return Promise.reject(`You must provide a ${missing} in order to login!`)
@@ -116,7 +119,8 @@ export default class Pixiv {
     /**
      * Logs in with refresh token only.
      */
-    public static refreshLogin = async (refreshToken: string) => {
+    public static refreshLogin = async (refreshToken: string, options?: AxiosRequestConfig) => {
+        updateAxiosInstance(options)
         data.refresh_token = refreshToken
         data.grant_type = "refresh_token"
         const result = await axios.post(oauthURL, stringify(data as unknown as ParsedUrlQueryInput), {headers} as AxiosRequestConfig).then((r) => r.data) as PixivAPIResponse


### PR DESCRIPTION
For example, this will enable user to add http proxy by doing this:
```js
const pixiv = await Pixiv.refreshLogin("xxx", {
  proxy: {
    host: "127.0.0.1",
    port: 7890
  }
})
```